### PR TITLE
fix creation of thumbs for images that are not world readable

### DIFF
--- a/lib/minigalnano/createthumb.php
+++ b/lib/minigalnano/createthumb.php
@@ -54,7 +54,7 @@ if (!is_file($imagefilename)) {
 }
 
 // Display error image if file exists, but can't be opened
-if (substr(decoct(fileperms($imagefilename)), -1, strlen(fileperms($imagefilename))) < 4 OR substr(decoct(fileperms($imagefilename)), -3,1) < 4) {
+if (!is_readable($imagefilename)) {
   header('Content-type: image/png');
   readfile('filecantbeopened.png');
   exit;


### PR DESCRIPTION
if the webserver doesn't give world read permissions to images which are uploaded in the bibliography module, the detail view in the OPAC can't create a thumbnail and displays filecantbeopened.png instead. 
The problem is that minigalnano has the arbitrary requirement that the image file is readable by the file owner and by others(at least chmod 404). That is not necessary in installations in which uploaded files belong to the user who runs the php-script.
