### PR TITLE
Fix label images

### DIFF
--- a/admin/modules/bibliography/biblio_utils.inc.php
+++ b/admin/modules/bibliography/biblio_utils.inc.php
@@ -144,7 +144,7 @@ function showTitleAuthors($obj_db, $array_data)
 	          $_label_d = $_label_q->fetch_row();
 	          $label_cache[$_label_d[0]] = array('name' => $_label_d[0], 'desc' => $_label_d[1], 'image' => $_label_d[2]);
 	      }
-	      $_output .= ' <img src="../images/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
+	      $_output .= ' <img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=24&amp;height=24" title="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
 	  }
 	}
   $_output .= '</div>';

--- a/admin/modules/bibliography/index.php
+++ b/admin/modules/bibliography/index.php
@@ -718,7 +718,7 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
     $checked = isset($arr_labels[$label_d['label_name']])?' checked':'';
     $url = isset($arr_labels[$label_d['label_name']])?$arr_labels[$label_d['label_name']]:'';
     $str_input .= '<div '
-    .'style="background: url('.SWB.IMG.'/labels/'.$label_d['label_image'].') left center no-repeat; padding-left: 30px; height: 45px;" class="'.$label_d['label_name'].'"> '
+    .'style="background: url('.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_d['label_image']).'&amp;width=24&amp;height=24) left center no-repeat; padding-left: 30px; height: 45px;" class="'.$label_d['label_name'].'"> '
     .'<input type="checkbox" name="labels[]" value="'.$label_d['label_name'].'"'.$checked.' /> '.$label_d['label_desc']
     .'<div>URL : <input type="text" title="Enter a website link/URL to make this label clickable" '
     .'name="label_urls['.$label_d['label_name'].']" size="50" maxlength="300" value="'.$url.'" /></div></div>';

--- a/admin/modules/master_file/label.php
+++ b/admin/modules/master_file/label.php
@@ -66,22 +66,11 @@ if (isset($_POST['saveData']) AND $can_read AND $can_write) {
             $image_upload = new simbio_file_upload();
             $image_upload->setAllowableFormat($sysconf['allowed_images']);
             $image_upload->setMaxSize($sysconf['max_image_upload']*1024);
-            $image_upload->setUploadDir(IMAGES_BASE_DIR.'labels');
+            $image_upload->setUploadDir(IMGBS.'labels');
             // upload
             $img_upload_status = $image_upload->doUpload('labelImage', $data['label_name']);
             if ($img_upload_status == UPLOAD_SUCCESS) {
-              $data['label_image'] = $dbs->escape_string($image_upload->new_filename.'.png');
-              // resize the image
-              if (function_exists('imagecopyresampled')) {
-                // we use phpthumb class to resize image
-                include LIB.'phpthumb/ThumbLib.inc.php';
-                // create phpthumb object
-                $src = IMAGES_BASE_DIR.'labels/'.$image_upload->new_filename;
-                $phpthumb = PhpThumbFactory::create($src);
-                $w = $h = 24;
-                $phpthumb->resize($w, $h);
-                $phpthumb->save(IMAGES_BASE_DIR.'labels/'.$data['label_name'].'.png', 'PNG');
-              }
+              $data['label_image'] = $dbs->escape_string($image_upload->new_filename);
               // write log
               utility::writeLogs($dbs, 'staff', $_SESSION['uid'], 'bibliography', $_SESSION['realname'].' upload label image file '.$image_upload->new_filename);
               utility::jsAlert('Label image file successfully uploaded');
@@ -212,7 +201,7 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
         $str_input .= ' Maximum '.$sysconf['max_image_upload'].' KB. All image will be automatically resized.';
         $form->addAnything(__('File Attachment'), $str_input);
     } else {
-        $str_input = '<div><img src="'.SWB.IMAGES_DIR.'/labels/'.$rec_d['label_image'].'" align="middle" /> <strong>'.$rec_d['label_image'].'</strong></div>';
+        $str_input = '<div><img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($rec_d['label_image']).'&amp;width=24&amp;height=24" align="middle" /> <strong>'.$rec_d['label_image'].'</strong></div>';
         $str_input .= simbio_form_element::textField('file', 'labelImage');
         $str_input .= ' Maximum '.$sysconf['max_image_upload'].' KB. All image will be automatically resized.';
         $form->addAnything(__('File Attachment'), $str_input);

--- a/lib/minigalnano/createthumb.php
+++ b/lib/minigalnano/createthumb.php
@@ -94,6 +94,13 @@ $target = imagecreatetruecolor($res_width,$res_height);
 if (preg_match("/.jpg$/i", $imagefilename)) $source = imagecreatefromjpeg($imagefilename);
 if (preg_match("/.gif$/i", $imagefilename)) $source = imagecreatefromgif($imagefilename);
 if (preg_match("/.png$/i", $imagefilename)) $source = imagecreatefrompng($imagefilename);
+
+// preserve transparency
+imagealphablending($target, false);
+imagesavealpha($target,true);
+$transparent = imagecolorallocatealpha($target, 255, 255, 255, 127);
+imagefilledrectangle($target, 0, 0, $res_width, $res_height, $transparent);
+
 imagecopyresampled($target,$source,0,0,$xoord,$yoord,$res_width,$res_height,$width,$height);
 imagedestroy($source);
 

--- a/template/classic/biblio_list_template.php
+++ b/template/classic/biblio_list_template.php
@@ -66,9 +66,9 @@ function biblio_list_format($dbs, $biblio_detail, $n, $settings = array(), &$ret
         }
 
         if (isset($label[1]) && $label[1]) {
-          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.IMAGES_DIR.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
+          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
         } else {
-          $title_link .= ' <img src="'.SWB.IMG.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
+          $title_link .= ' <img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
         }
       }
     }

--- a/template/default/biblio_list_template.php
+++ b/template/default/biblio_list_template.php
@@ -66,9 +66,9 @@ function biblio_list_format($dbs, $biblio_detail, $n, $settings = array(), &$ret
         }
 
         if (isset($label[1]) && $label[1]) {
-          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.IMAGES_DIR.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
+          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
         } else {
-          $title_link .= ' <img src="'.SWB.IMG.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
+          $title_link .= ' <img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
         }
       }
     }

--- a/template/lightweight/biblio_list_template.php
+++ b/template/lightweight/biblio_list_template.php
@@ -66,9 +66,9 @@ function biblio_list_format($dbs, $biblio_detail, $n, $settings = array(), &$ret
         }
 
         if (isset($label[1]) && $label[1]) {
-          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.IMAGES_DIR.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
+          $title_link .= ' <a itemprop="name" property="name" href="'.$label[1].'" target="_blank"><img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" border="0" /></a>';
         } else {
-          $title_link .= ' <img src="'.SWB.IMG.'/labels/'.$label_cache[$label[0]]['image'].'" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
+          $title_link .= ' <img src="'.SWB.'lib/minigalnano/createthumb.php?filename=../../'.IMG.'/labels/'.urlencode($label_cache[$label[0]]['image']).'&amp;width=48&amp;height=48" title="'.$label_cache[$label[0]]['desc'].'" alt="'.$label_cache[$label[0]]['desc'].'" align="middle" class="labels" />';
         }
       }
     }


### PR DESCRIPTION
-  replace non-existing constants so that the upload folder is found
- use minigalnano instead of phpthumb(which is not in the repository anymore) to dynamically create thumbnails
- preserve transparency in thumbnails

The last change affects all thumbnails which are created by minigalnano. You can leave out this commit if it is not desired
