### PR TITLE
Add missing keys and autoincrement

### DIFF
--- a/install/senayan.sql
+++ b/install/senayan.sql
@@ -1127,7 +1127,9 @@ CREATE TABLE IF NOT EXISTS `mst_carrier_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `media_type` (`carrier_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
@@ -1204,7 +1206,9 @@ CREATE TABLE IF NOT EXISTS `mst_content_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `content_type` (`content_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
@@ -1251,7 +1255,9 @@ CREATE TABLE IF NOT EXISTS `mst_media_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `media_type` (`media_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --

--- a/install/senayan.sql
+++ b/install/senayan.sql
@@ -1121,12 +1121,13 @@ CREATE TABLE IF NOT EXISTS `comment` (
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=1;
 
 CREATE TABLE IF NOT EXISTS `mst_carrier_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `carrier_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
@@ -1197,12 +1198,13 @@ INSERT INTO `mst_carrier_type` (`id`, `carrier_type`, `code`, `code2`, `input_da
 --
 
 CREATE TABLE IF NOT EXISTS `mst_content_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `content_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
@@ -1243,12 +1245,13 @@ INSERT INTO `mst_content_type` (`id`, `content_type`, `code`, `code2`, `input_da
 --
 
 CREATE TABLE IF NOT EXISTS `mst_media_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `media_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 --
@@ -1272,9 +1275,10 @@ INSERT INTO `mst_media_type` (`id`, `media_type`, `code`, `code2`, `input_date`,
 --
 
 CREATE TABLE IF NOT EXISTS `mst_relation_term` (
-`ID` int(11) NOT NULL,
+`ID` int(11) NOT NULL AUTO_INCREMENT,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
+  `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`ID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=13 ;
 
 --
@@ -1290,10 +1294,11 @@ INSERT INTO `mst_relation_term` (`ID`, `rt_id`, `rt_desc`) VALUES
 (6, 'SA', 'See Also');
 
 CREATE TABLE IF NOT EXISTS `mst_voc_ctrl` (
-  `topic_id` int(11) NOT NULL,
+  `topic_id` int(11) NOT NULL AUTO_INCREMENT,
 `vocabolary_id` int(11) NOT NULL,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `related_topic_id` varchar(250) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
+  `related_topic_id` varchar(250) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`topic_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
 
 CREATE TABLE IF NOT EXISTS `biblio_relation` (

--- a/install/senayan.sql
+++ b/install/senayan.sql
@@ -1279,7 +1279,7 @@ CREATE TABLE IF NOT EXISTS `mst_relation_term` (
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   PRIMARY KEY (`ID`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=13 ;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=7 ;
 
 --
 -- Dumping data for table `mst_relation_term`

--- a/install/senayan.sql.php
+++ b/install/senayan.sql.php
@@ -779,47 +779,52 @@ CREATE TABLE IF NOT EXISTS `comment` (
 
 $sql['create'][] = "
 CREATE TABLE IF NOT EXISTS `mst_carrier_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `carrier_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "
 CREATE TABLE IF NOT EXISTS `mst_content_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `content_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "
 CREATE TABLE IF NOT EXISTS `mst_media_type` (
-`id` int(11) NOT NULL,
+`id` int(11) NOT NULL AUTO_INCREMENT,
   `media_type` varchar(100) COLLATE utf8_unicode_ci NOT NULL,
   `code` varchar(5) COLLATE utf8_unicode_ci NOT NULL,
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
-  `last_update` datetime NOT NULL
+  `last_update` datetime NOT NULL,
+  PRIMARY KEY (`id`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "
 CREATE TABLE IF NOT EXISTS `mst_relation_term` (
-`ID` int(11) NOT NULL,
+`ID` int(11) NOT NULL AUTO_INCREMENT,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
+  `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`ID`)
 ) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=13 ;";
 
 $sql['create'][] = "
 CREATE TABLE IF NOT EXISTS `mst_voc_ctrl` (
-  `topic_id` int(11) NOT NULL,
+  `topic_id` int(11) NOT NULL AUTO_INCREMENT,
 `vocabolary_id` int(11) NOT NULL,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
-  `related_topic_id` varchar(250) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
+  `related_topic_id` varchar(250) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
+  PRIMARY KEY (`topic_id`)
 ) ENGINE=MyISAM  DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "

--- a/install/senayan.sql.php
+++ b/install/senayan.sql.php
@@ -785,7 +785,9 @@ CREATE TABLE IF NOT EXISTS `mst_carrier_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `media_type` (`carrier_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=56 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "
@@ -796,7 +798,9 @@ CREATE TABLE IF NOT EXISTS `mst_content_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `content_type` (`content_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=26 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "
@@ -807,7 +811,9 @@ CREATE TABLE IF NOT EXISTS `mst_media_type` (
   `code2` char(1) COLLATE utf8_unicode_ci NOT NULL,
   `input_date` datetime NOT NULL,
   `last_update` datetime NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `media_type` (`media_type`),
+  KEY `code` (`code`)
 ) ENGINE=MyISAM AUTO_INCREMENT=11 DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;";
 
 $sql['create'][] = "

--- a/install/sql_php_upgrade/upgrade_slims8_akasia.sql.php
+++ b/install/sql_php_upgrade/upgrade_slims8_akasia.sql.php
@@ -238,13 +238,13 @@ $sql['alter'][] = "ALTER TABLE `mst_voc_ctrl`
 -- AUTO_INCREMENT for table `mst_relation_term`
 --*/
 $sql['alter'][] = "ALTER TABLE `mst_relation_term`
-MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=13;";
+MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=7;";
 
 /*--
 -- AUTO_INCREMENT for table `mst_voc_ctrl`
 --*/
 $sql['alter'][] = "ALTER TABLE `mst_voc_ctrl`
-MODIFY `vocabolary_id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=43;";
+MODIFY `vocabolary_id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=1;";
 
 $sql['alter'][] = "ALTER TABLE `mst_carrier_type`
  ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`carrier_type`), ADD KEY `code` (`code`);";
@@ -256,7 +256,7 @@ $sql['alter'][] = "ALTER TABLE `mst_media_type`
  ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`media_type`), ADD KEY `code` (`code`);";
 
 $sql['alter'][] = "ALTER TABLE `mst_carrier_type`
-MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=51;";
+MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=56;";
 
 $sql['alter'][] = "ALTER TABLE `mst_content_type`
 MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=26;";

--- a/install/sql_php_upgrade/upgrade_slims8_akasia.sql.php
+++ b/install/sql_php_upgrade/upgrade_slims8_akasia.sql.php
@@ -176,7 +176,7 @@ $sql['create'][] = "CREATE TABLE IF NOT EXISTS `mst_relation_term` (
 `ID` int(11) NOT NULL,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=13 ;";
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=7 ;";
 
 /*--
 -- Dumping data for table `mst_relation_term`

--- a/lib/lang/locale/de_DE/German_Sample_Data_ -_Slims8_Akasia_2016-05-28.sql
+++ b/lib/lang/locale/de_DE/German_Sample_Data_ -_Slims8_Akasia_2016-05-28.sql
@@ -768,6 +768,46 @@ ALTER TABLE `mst_topic`
   ADD PRIMARY KEY (`topic_id`),
   ADD UNIQUE KEY `topic` (`topic`,`topic_type`);
 
+--
+-- Indexes for table `mst_relation_term`
+--
+ALTER TABLE `mst_relation_term`
+ ADD PRIMARY KEY (`ID`);
+
+--
+-- Indexes for table `mst_voc_ctrl`
+--
+ALTER TABLE `mst_voc_ctrl`
+ ADD PRIMARY KEY (`vocabolary_id`);
+
+--
+-- AUTO_INCREMENT for table `mst_relation_term`
+--
+ALTER TABLE `mst_relation_term`
+MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT;
+--
+-- AUTO_INCREMENT for table `mst_voc_ctrl`
+--
+ALTER TABLE `mst_voc_ctrl`
+MODIFY `vocabolary_id` int(11) NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `mst_carrier_type`
+ ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`carrier_type`), ADD KEY `code` (`code`);
+
+ALTER TABLE `mst_content_type`
+ ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `content_type` (`content_type`), ADD KEY `code` (`code`);
+
+ALTER TABLE `mst_media_type`
+ ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`media_type`), ADD KEY `code` (`code`);
+
+ALTER TABLE `mst_carrier_type`
+MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `mst_content_type`
+MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
+
+ALTER TABLE `mst_media_type`
+MODIFY `id` int(11) NOT NULL AUTO_INCREMENT;
 
 /*!40101 SET CHARACTER_SET_CLIENT=@OLD_CHARACTER_SET_CLIENT */;
 /*!40101 SET CHARACTER_SET_RESULTS=@OLD_CHARACTER_SET_RESULTS */;

--- a/upgrade/upgrade_slims8_akasia.sql
+++ b/upgrade/upgrade_slims8_akasia.sql
@@ -241,7 +241,7 @@ ALTER TABLE `mst_voc_ctrl`
 -- AUTO_INCREMENT for table `mst_relation_term`
 --
 ALTER TABLE `mst_relation_term`
-MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=13;
+MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=7;
 --
 -- AUTO_INCREMENT for table `mst_voc_ctrl`
 --

--- a/upgrade/upgrade_slims8_akasia.sql
+++ b/upgrade/upgrade_slims8_akasia.sql
@@ -177,7 +177,7 @@ CREATE TABLE IF NOT EXISTS `mst_relation_term` (
 `ID` int(11) NOT NULL,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `rt_desc` varchar(50) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=13 ;
+) ENGINE=MyISAM DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci AUTO_INCREMENT=7 ;
 
 --
 -- Dumping data for table `mst_relation_term`
@@ -219,7 +219,7 @@ CREATE TABLE IF NOT EXISTS `mst_voc_ctrl` (
 `vocabolary_id` int(11) NOT NULL,
   `rt_id` varchar(11) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
   `related_topic_id` varchar(250) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL
-) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=43 ;
+) ENGINE=MyISAM  DEFAULT CHARSET=latin1 AUTO_INCREMENT=1 ;
 
 
 INSERT IGNORE INTO `setting` (`setting_name`, `setting_value`) VALUES
@@ -246,7 +246,7 @@ MODIFY `ID` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=13;
 -- AUTO_INCREMENT for table `mst_voc_ctrl`
 --
 ALTER TABLE `mst_voc_ctrl`
-MODIFY `vocabolary_id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=43;
+MODIFY `vocabolary_id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=1;
 
 ALTER TABLE `mst_carrier_type`
  ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`carrier_type`), ADD KEY `code` (`code`);
@@ -258,7 +258,7 @@ ALTER TABLE `mst_media_type`
  ADD PRIMARY KEY (`id`), ADD UNIQUE KEY `media_type` (`media_type`), ADD KEY `code` (`code`);
 
 ALTER TABLE `mst_carrier_type`
-MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=51;
+MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=56;
 
 ALTER TABLE `mst_content_type`
 MODIFY `id` int(11) NOT NULL AUTO_INCREMENT,AUTO_INCREMENT=26;


### PR DESCRIPTION
in the install script there are tables without a primary key and autoincrement:
- mst_carrier_type
- mst_content_type
- mst_media_type
- mst_relation_term
- mst_voc_ctrl
  This is fixed in the first commit.

The second commit change the autoincrement values which didn't always reflect the amount of data which is inserted in the install/upgrade script
