### PR TITLE
Prevent password autocomplete in new member form

### DIFF
--- a/admin/modules/bibliography/index.php
+++ b/admin/modules/bibliography/index.php
@@ -591,14 +591,14 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
   }
   $str_input  = '<a class="notAJAX btn btn-primary openPopUp notIframe" href="'.MWB.'bibliography/pop_pattern.php" height="420px" title="'.__('Add new pattern').'"><i class="glyphicon glyphicon-plus"></i> Add New Pattern</a>&nbsp;';
   $str_input .= simbio_form_element::selectList('itemCodePattern', $pattern_options, '', 'style="width: auto"').' &nbsp;';
-  $str_input .= __('Total item(s)').': <input type="text" class="small_input" style="width: 100px;" name="totalItems" value="0" /> &nbsp;';
+  $str_input .= '<label id="totalItemsLabel">' . __('Total item(s)').':</label> <input type="text" class="small_input" style="width: 100px;" name="totalItems" value="0" /> &nbsp;';
   // get collection type data related to this record from database
     $coll_type_q = $dbs->query("SELECT coll_type_id, coll_type_name FROM mst_coll_type");
     $coll_type_options = array();
     while ($coll_type_d = $coll_type_q->fetch_row()) {
         $coll_type_options[] = array($coll_type_d[0], $coll_type_d[1]);
     }
-  $str_input .= __('Collection Type').': '.simbio_form_element::selectList('collTypeID', $coll_type_options, '', 'style="width: 100px;"');;
+  $str_input .= '<label id="collTypeIDLabel">' . __('Collection Type').':</label> '.simbio_form_element::selectList('collTypeID', $coll_type_options, '', 'style="width: 100px;"');;
   $form->addAnything(__('Item(s) code batch generator'), $str_input);
   // biblio item add
   if (!$in_pop_up AND $form->edit_mode) {

--- a/admin/modules/membership/index.php
+++ b/admin/modules/membership/index.php
@@ -510,9 +510,9 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
     // member email
     $form->addTextField('text', 'memberEmail', __('E-mail'), $rec_d['member_email'], 'style="width: 40%;"');
     // member password
-    $form->addTextField('password', 'memberPasswd', __('New Password'), null, 'style="width: 40%;"');
+    $form->addTextField('password', 'memberPasswd', __('New Password'), null, 'style="width: 40%;" autocomplete="new-password"');
     // member password confirmation
-    $form->addTextField('password', 'memberPasswd2', __('Confirm New Password'), null, 'style="width: 40%;"');
+    $form->addTextField('password', 'memberPasswd2', __('Confirm New Password'), null, 'style="width: 40%;" autocomplete="new-password"');
 
     // edit mode messagge
     if ($form->edit_mode) {

--- a/admin/modules/membership/index.php
+++ b/admin/modules/membership/index.php
@@ -507,6 +507,11 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
 
     $form->addAnything(__('Photo'), $str_input);
 
+    // hidden username and password fields so that the password manager of the browser will not fill in the username in the memberEmail and the password in the memberPasswd field
+    $form->addTextField('text', 'dummyUserField', null, null, '');
+    $form->addTextField('password', 'dummyPasswdField', null, null, '');
+    echo '<style type="text/css">#simbioFormRowdummyPasswdField, #simbioFormRowdummyUserField {display: none}</style>';
+
     // member email
     $form->addTextField('text', 'memberEmail', __('E-mail'), $rec_d['member_email'], 'style="width: 40%;"');
     // member password

--- a/simbio2/simbio_GUI/form_maker/simbio_form_table_AJAX.inc.php
+++ b/simbio2/simbio_GUI/form_maker/simbio_form_table_AJAX.inc.php
@@ -83,6 +83,10 @@ class simbio_form_table_AJAX extends simbio_form_maker
          }
          // append row
          $_table->appendTableRow(array($row['label'], ':', $_form_element));
+         if(!empty($row['element']->element_name))
+         {
+            $_table->setCellAttr($_row_num+1, null, 'id="simbioFormRow' . $row['element']->element_name . '"');
+         }
          // set the column header attr
          $_table->setCellAttr($_row_num+1, 0, 'width="20%" valign="top"'.$this->table_header_attr);
          $_table->setCellAttr($_row_num+1, 1, 'width="1%" valign="top"'.$this->table_header_attr);


### PR DESCRIPTION
If a system user saved their username and password in their browser, the browser uses it not only in the login form, but also in other forms which have a input field of type password. That is the case in the membership module when creating a new member.

In Firefox(tested with Firefox 50.1.0 on Ubuntu 16.10), if only one password was saved for the site, the email-field is automatically filled with the username and the password is put in the first password field.

In Google Chrome/Chromium(tested with Chromium 55.0.2883.87 on Ubuntu 16.10) the email-field shows the username in a popup and if the user clicks on it, the password is put in the first password field. Also the password fields show a popup "Use password for: <username>".

Chromium/Chrome support autocomplete="new-password" for the password fields which at least prevents the popup in the email-field. But even though [the documentation](https://developer.mozilla.org/en-US/docs/Web/Security/Securing_your_site/Turning_off_form_autocompletion#The_autocomplete_attribute_and_login_fields) mentions autocomplete="new-password" as a solution it seems that this is not supported by firefox.

As a workaround for firefox this pull request adds a hidden dummyUserField and dummyPasswdField to the new member form. These fields are located before the email and password fields so that they are filled by the password manager. To prevent the user from seeing these fields they are hidden by css. To hide the whole row it needs an id. Therefore the commit "add id to tr elements in forms for better styling" is included in this pull request.

