### PR TITLE
don't save member if a password is specified, but the password confirmation is empty

### DIFF
--- a/admin/modules/membership/index.php
+++ b/admin/modules/membership/index.php
@@ -85,7 +85,7 @@ if (isset($_POST['saveData']) AND $can_read AND $can_write) {
     if (empty($memberID) OR empty($memberName)) {
         utility::jsAlert(__('Member ID and Name can\'t be empty')); //mfc
         exit();
-    } else if (($mpasswd1 AND $mpasswd2) AND ($mpasswd1 !== $mpasswd2)) {
+    } else if (($mpasswd1 OR $mpasswd2) AND ($mpasswd1 !== $mpasswd2)) {
         utility::jsAlert(__('Password confirmation does not match. See if your Caps Lock key is on!'));
         exit();
     } else {


### PR DESCRIPTION
prevent saving of a member if a new password,
but not the confirmation is entered. An error
message is shown instead. The same happens if
only the confirmation, but no password was entered