### PR TITLE
use current date if fines date is empty

### DIFF
--- a/admin/modules/circulation/fines_list.php
+++ b/admin/modules/circulation/fines_list.php
@@ -69,7 +69,11 @@ if (isset($_POST['saveData'])) {
         utility::jsAlert(''.__('Value of Credit can not be higher that Debet Value').'');
     } else {
         $data['member_id'] = $_SESSION['memberID'];
-        $data['fines_date'] = trim($dbs->escape_string(strip_tags($_POST['finesDate'])));
+        if (empty($_POST['finesDate'])) {
+            $data['fines_date'] = date('Y-m-d');
+        } else {
+            $data['fines_date'] = trim($dbs->escape_string(strip_tags($_POST['finesDate'])));
+        }
         $data['description'] = trim($dbs->escape_string(strip_tags($_POST['finesDesc'])));
         $data['debet'] = $debet;
         $data['credit'] = $credit;


### PR DESCRIPTION
When adding a new fine in the fines list in the circulation module, the fines date is not marked as a mandatory field, but there is an error message if you try to save a fine without a date.
This pull request allows the date to be empty. In this case the current date is used as the fines date.