### PR TITLE
use oninput instead of onkeyup and onchange

### DIFF
--- a/admin/modules/bibliography/pop_author.php
+++ b/admin/modules/bibliography/pop_author.php
@@ -142,7 +142,7 @@ if (isset($_POST['save']) AND (isset($_POST['authorID']) OR trim($_POST['search_
     <form name="searchAuthor" method="post" style="display: inline;">
     <?php
     $ajax_exp = "ajaxFillSelect('../../AJAX_lookup_handler.php', 'mst_author', 'author_id:author_name:author_year:authority_type', 'authorID', $('#search_str').val())";
-    echo __('Author Name'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" onkeyup="<?php echo $ajax_exp; ?>" onchange="<?php echo $ajax_exp; ?>" />
+    echo __('Author Name'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" oninput="<?php echo $ajax_exp; ?>"  />
     <select name="type" style="width: 20%;"><?php
     foreach ($sysconf['authority_type'] as $type_id => $type) {
         echo '<option value="'.$type_id.'">'.$type.'</option>';

--- a/admin/modules/bibliography/pop_biblio_rel.php
+++ b/admin/modules/bibliography/pop_biblio_rel.php
@@ -88,7 +88,7 @@ if (isset($_POST['save']) AND (isset($_POST['biblioID']) OR trim($_POST['search_
     <form name="searchBiblio" method="post" style="display: inline;">
     <?php
     $ajax_exp = "ajaxFillSelect('../../AJAX_lookup_handler.php', 'biblio', 'biblio_id:title:edition:publish_year', 'relBiblioID', $('#search_str').val())";
-    echo __('Title'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" onkeyup="<?php echo $ajax_exp; ?>" onchange="<?php echo $ajax_exp; ?>" />
+    echo __('Title'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" oninput="<?php echo $ajax_exp; ?>" />
 </div>
 <div class="popUpSubForm">
 <select name="relBiblioID" id="relBiblioID" size="5" style="width: 100%;"><option value="0"><?php echo __('Type to search for existing biblio data'); ?></option></select>

--- a/admin/modules/bibliography/pop_topic.php
+++ b/admin/modules/bibliography/pop_topic.php
@@ -144,7 +144,7 @@ if (isset($_POST['save']) AND (isset($_POST['topicID']) OR trim($_POST['search_s
     <?php
     $ajax_exp = "ajaxFillSelect('../../AJAX_vocabolary_control.php', 'mst_topic', 'topic_id:topic:topic_type', 'topicID', $('#search_str').val())";
     ?>
-    <?php echo __('Keyword'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" onkeyup="<?php echo $ajax_exp; ?>" />
+    <?php echo __('Keyword'); ?> : <input type="text" name="search_str" id="search_str" style="width: 30%;" oninput="<?php echo $ajax_exp; ?>" />
     <select name="type" style="width: 20%;"><?php
     foreach ($sysconf['subject_type'] as $type_id => $type) {
         echo '<option value="'.$type_id.'">'.$type.'</option>';

--- a/admin/modules/circulation/reserve_list.php
+++ b/admin/modules/circulation/reserve_list.php
@@ -71,7 +71,7 @@ function confirmProcess(intReserveID, strTitle)
         // AJAX expression
         $ajax_exp = "ajaxFillSelect('item_AJAX_lookup_handler.php', 'item', 'i.item_code:title', 'reserveItemID', $('#bib_search_str').val())";
         $biblio_options[] = array('0', 'Title');
-        echo simbio_form_element::textField('text', 'bib_search_str', '', 'style="width: 10%;" onkeyup="'.$ajax_exp.'"');
+        echo simbio_form_element::textField('text', 'bib_search_str', '', 'style="width: 10%;" oninput="'.$ajax_exp.'"');
         echo simbio_form_element::selectList('reserveItemID', $biblio_options, '', 'class="marginTop" style="width: 70%;"');
         echo simbio_form_element::textField('submit', 'addReserve', __('Add Reserve'));
         ?>

--- a/admin/modules/master_file/pop_vocabolary_control.php
+++ b/admin/modules/master_file/pop_vocabolary_control.php
@@ -221,7 +221,7 @@ if (isset($_GET['editTopic'])) {
       <?php
       $ajax_exp = "ajaxFillSelect('../../AJAX_lookup_handler.php', 'mst_topic', 'topic_id:topic:topic_type', 'topicID', $('#search_str').val())";
       ?>
-      <input type="text" value="<?php echo $topic_d[0];?>" name="search_str" id="search_str" class="form-control" placeholder="Vocabulary" onkeyup="<?php echo $ajax_exp; ?>" />
+      <input type="text" value="<?php echo $topic_d[0];?>" name="search_str" id="search_str" class="form-control" placeholder="Vocabulary" oninput="<?php echo $ajax_exp; ?>" />
       <select name="topicID" id="topicID" size="5" class="form-control"><option value="0"><?php echo __('Type to search for existing topics or to add a new one'); ?></option></select>
       </div>
     </div>
@@ -269,7 +269,7 @@ if (isset($_GET['editTopic'])) {
     <?php
     $ajax_exp = "ajaxFillSelect('../../AJAX_lookup_handler.php', 'mst_topic', 'topic_id:topic:topic_type', 'topicID', $('#search_str').val())";
     ?>
-    <input type="text" name="search_str" id="search_str" class="form-control" placeholder="<?php echo __('Enter Vocabulary');?>" onkeyup="<?php echo $ajax_exp; ?>" />
+    <input type="text" name="search_str" id="search_str" class="form-control" placeholder="<?php echo __('Enter Vocabulary');?>" oninput="<?php echo $ajax_exp; ?>" />
     <select name="topicID" id="topicID" size="5" class="form-control"><option value="0"><?php echo __('Type to search for existing topics or to add a new one'); ?></option></select>
     </div>
   </div>


### PR DESCRIPTION
Replace onkeyup and onchange by oninput in several popups.

pop_author and pop_biblio_rel used onkeyup and onchange. Therefore, a mouse click on an author/biblio in the search result list triggers the onchange event and reloads the list which unselects the element on which you clicked. oninput avoids that, because it is triggered by changes to the input field and not by any mouseclicks that unfocus the input field.

the rest of the code only used onkeyup. That has the problem that it is not triggered by copy&paste if the paste is done with the mouse

WARNING: this change doesn't work in IE 8 or below