### PR TITLE
add option to disable title basket

### DIFF
--- a/lib/contents/default.inc.php
+++ b/lib/contents/default.inc.php
@@ -54,6 +54,9 @@ try {
 if (isset($sysconf['enable_xml_detail']) && !$sysconf['enable_xml_detail']) {
   $biblio_list->xml_detail = false;
 }
+if (isset($sysconf['enable_mark']) && !$sysconf['enable_mark']) {
+  $biblio_list->enable_mark = false;
+}
 
 // search result info
 $search_result_info = '';

--- a/lib/contents/member.inc.php
+++ b/lib/contents/member.inc.php
@@ -699,10 +699,14 @@ if (!$is_member_login) {
     echo '</div>';
     echo showLoanHist();
     echo '</div>';
+
+    // default is to show the title basket
+    if (!isset($sysconf['enable_mark']) || $sysconf['enable_mark']) {
 	echo '<div class="tagline">';
-    echo '<div class="memberInfoHead">'.__('Your Title Basket').'</div><a name="biblioBasket"></a>'."\n";
-    echo showBasket();
-    echo '</div>';
+        echo '<div class="memberInfoHead">'.__('Your Title Basket').'</div><a name="biblioBasket"></a>'."\n";
+        echo showBasket();
+        echo '</div>';
+    }
     // change password only form NATIVE authentication, not for others such as LDAP
     if ($sysconf['auth']['member']['method'] == 'native') {
 	echo '<div class="tagline">';

--- a/sysconfig.inc.php
+++ b/sysconfig.inc.php
@@ -191,6 +191,9 @@ $sysconf['promote_first_emphasized'] = true;
 $sysconf['content']['allowable_tags'] = '<p><a><cite><code><em><strong><cite><blockquote><fieldset><legend>'
     .'<h3><hr><br><table><tr><td><th><thead><tbody><tfoot><div><span><img><object><param>';
 
+/* allow logged in members to mark bibliography titles, show the title basket in the member details and send a mail to reserve these titles */
+$sysconf['enable_mark'] = true;
+
 /* XML */
 $sysconf['enable_xml_detail'] = true;
 $sysconf['enable_xml_result'] = true;


### PR DESCRIPTION
the new sysconfig option is called "enable_mark",
because that's the term that was already used
in the class biblio_list_model
if you set this option to false in sysconfig.local.inc.php
the title basket is hidden in the member area and the buttons
to add titles from the search list to the basket are removed
if this option is not set, or set to true the basket is shown