### PR TITLE
Fix holiday calculation

### DIFF
--- a/admin/modules/circulation/circulation_action.php
+++ b/admin/modules/circulation/circulation_action.php
@@ -111,8 +111,8 @@ if (isset($_POST['process']) AND isset($_POST['loanID'])) {
     // create circulation object
     $circulation = new circulation($dbs, $dbs->escape_string($_SESSION['memberID']));
     $circulation->ignore_holidays_fine_calc = $sysconf['ignore_holidays_fine_calc'];
-	$circulation->holiday_dayname = $dbs->escape_string($_SESSION['holiday_dayname']);
-	$circulation->holiday_date = $dbs->escape_string($_SESSION['holiday_date']);
+	$circulation->holiday_dayname = $_SESSION['holiday_dayname'];
+	$circulation->holiday_date = $_SESSION['holiday_date'];
     if ($_POST['process'] == 'return') {
         $return_status = $circulation->returnItem($loanID);
         // write log
@@ -127,8 +127,8 @@ if (isset($_POST['process']) AND isset($_POST['loanID'])) {
         echo '</script>';
     } else {
         // set holiday settings
-        $circulation->holiday_dayname = $dbs->escape_string($_SESSION['holiday_dayname']);
-        $circulation->holiday_date = $dbs->escape_string($_SESSION['holiday_date']);
+        $circulation->holiday_dayname = $_SESSION['holiday_dayname'];
+        $circulation->holiday_date = $_SESSION['holiday_date'];
         $extend_status = $circulation->extendItemLoan($loanID);
         if ($extend_status === ITEM_RESERVED) {
             echo '<script type="text/javascript">';
@@ -156,8 +156,8 @@ if (isset($_POST['tempLoanID'])) {
     // create circulation object
     $circulation = new circulation($dbs, $dbs->escape_string($_SESSION['memberID']));
     // set holiday settings
-    $circulation->holiday_dayname = $dbs->escape_string($_SESSION['holiday_dayname']);
-    $circulation->holiday_date = $dbs->escape_string($_SESSION['holiday_date']);
+    $circulation->holiday_dayname = $_SESSION['holiday_dayname'];
+    $circulation->holiday_date = $_SESSION['holiday_date'];
     // add item to loan session
     $add = $circulation->addLoanSession(trim($_POST['tempLoanID']));
     if ($add == LOAN_LIMIT_REACHED) {
@@ -238,8 +238,8 @@ if (isset($_POST['overrideID']) AND !empty($_POST['overrideID'])) {
     // create circulation object
     $circulation = new circulation($dbs, $dbs->escape_string($_SESSION['memberID']));
     // set holiday settings
-    $circulation->holiday_dayname = $dbs->escape_string($_SESSION['holiday_dayname']);
-    $circulation->holiday_date = $dbs->escape_string($_SESSION['holiday_date']);
+    $circulation->holiday_dayname = $_SESSION['holiday_dayname'];
+    $circulation->holiday_date = $_SESSION['holiday_date'];
     // add item to loan session
     $add = $circulation->addLoanSession($_POST['overrideID']);
     echo '<script type="text/javascript">';
@@ -283,8 +283,8 @@ if (isset($_POST['quickReturnID']) AND $_POST['quickReturnID']) {
 
         /* modified by Indra Sutriadi */
         $circulation->ignore_holidays_fine_calc = $sysconf['ignore_holidays_fine_calc'];
-        $circulation->holiday_dayname = $dbs->escape_string($_SESSION['holiday_dayname']);
-        $circulation->holiday_date = $dbs->escape_string($_SESSION['holiday_date']);
+        $circulation->holiday_dayname = $_SESSION['holiday_dayname'];
+        $circulation->holiday_date = $_SESSION['holiday_date'];
         /* end of modification */
 
         // check for overdue

--- a/admin/modules/system/holiday.php
+++ b/admin/modules/system/holiday.php
@@ -268,7 +268,7 @@ if (isset($_GET['mode'])) {
                 // emptying holiday dayname session first
                 $_SESSION['holiday_dayname'] = array();
                 foreach ($_POST['dayname'] as $dayname) {
-                    $dbs->query("INSERT INTO holiday VALUES(NULL, '$dayname', NULL, NULL)");
+                    $dbs->query("INSERT INTO holiday VALUES(NULL, '" . $dbs->escape_string($dayname) . "', NULL, NULL)");
                     // update holiday_dayname session
                     $_SESSION['holiday_dayname'][] = $dayname;
                 }

--- a/admin/modules/system/holiday.php
+++ b/admin/modules/system/holiday.php
@@ -58,7 +58,11 @@ if (isset($_POST['saveData']) AND $can_read AND $can_write) {
         utility::jsAlert(__('Holiday description can\'t be empty!'));
         exit();
     } else {
-        $data['holiday_date'] = trim(preg_replace('@\s[0-9]{2}:[0-9]{2}:[0-9]{2}$@i', '', $_POST['holDate']));
+        $data['holiday_date'] = trim($_POST['holDate']); // remove extra whitespace
+        if(!preg_match('@^[0-9]{4}-[0-9]{2}-[0-9]{2}$@', $data['holiday_date'])) {
+            utility::jsAlert(__('Holiday Date Start must have the format YYYY-MM-DD!'));
+            exit();
+        }
         $holiday_start_date = $data['holiday_date'];
         $data['holiday_dayname'] = date('D', strtotime($data['holiday_date']));
         $data['description'] = $holDesc;
@@ -86,8 +90,12 @@ if (isset($_POST['saveData']) AND $can_read AND $can_write) {
                 // update holiday_dayname session
                 $_SESSION['holiday_date'][$data['holiday_date']] = $data['holiday_date'];
                 // date range insert
-                if (isset($_POST['holDateEnd'])) {
-                    $holiday_end_date = trim(preg_replace('@\s[0-9]{2}:[0-9]{2}:[0-9]{2}$@i', '', $_POST['holDateEnd']));
+                if (!empty($_POST['holDateEnd'])) {
+                    $holiday_end_date = trim($_POST['holDateEnd']); // remove extra whitespace
+                    if(!preg_match('@^[0-9]{4}-[0-9]{2}-[0-9]{2}$@', $holiday_end_date)) {
+                        utility::jsAlert(__('Holiday Date End must have the format YYYY-MM-DD if it is not empty!'));
+                        exit();
+                    }
                     // check if holiday end date is more than holiday start date
                     if (simbio_date::compareDates($holiday_start_date, $holiday_end_date) == $holiday_end_date) {
                         $guard = 365;


### PR DESCRIPTION
The commit https://github.com/slims/slims8_akasia/commit/9d10ddc36ff22e7301a8c33644404ca6f76b623d broke the calculation of return dates during holidays. I commented on that commit, but never got a reply.
The commits in this pull request remove the unnecessary $dbs->escape_string from the circulation and add escaping and input validation to holiday.php where it is necessary.