### PR TITLE
fix calculation of fine warning again

### DIFF
--- a/admin/modules/circulation/circulation_action.php
+++ b/admin/modules/circulation/circulation_action.php
@@ -533,14 +533,8 @@ if (isset($_POST['memberID']) OR isset($_SESSION['memberID'])) {
 
         $fines_alert = FALSE;
         $total_unpaid_fines = 0;
-        $_unpaid_fines = $dbs->query('SELECT * FROM fines WHERE member_id=\''.$dbs->escape_string($_SESSION['memberID']).'\' AND debet > credit');
-        $unpaid_fines = $_unpaid_fines->fetch_assoc();
-        if (!empty($unpaid_fines)) {
-            foreach ($unpaid_fines as $key => $value) {
-                $total_unpaid_fines = $total_unpaid_fines + $value['3'];
-            }
-        }
-        if ($total_unpaid_fines > 0) {
+        $_unpaid_fines = $dbs->query('SELECT 1 FROM fines WHERE member_id=\''.$dbs->escape_string($_SESSION['memberID']).'\' AND debet > credit LIMIT 1');
+        if($_unpaid_fines->fetch_row()) {
             $fines_alert = TRUE;
         }
 


### PR DESCRIPTION
it was broken by a wrong merge in https://github.com/slims/slims8_akasia/commit/d2cae670588b9b924deca768e63ab9f63eeae1a5
I tried to comment on that commit, but didn't get a reply.

In this pull request I optimized the code a little, because we only need to know if there are fines to mark the tab in red. The exact amount of fines doesn't matter at this point.