### PR TITLE
fix overdue days calculation when daylight savings time starts

### DIFF
--- a/simbio2/simbio_UTILS/simbio_date.inc.php
+++ b/simbio2/simbio_UTILS/simbio_date.inc.php
@@ -100,7 +100,7 @@ class simbio_date
         $_start_mktime = mktime(0, 0, 0, $_parsed_start_date['month'], $_parsed_start_date['day'], $_parsed_start_date['year']);
         $_end_mktime = mktime(0, 0, 0, $_parsed_end_date['month'], $_parsed_end_date['day'], $_parsed_end_date['year']);
         $_mksec = $_end_mktime-$_start_mktime;
-        return abs(intval($_mksec/(3600*24)));
+        return abs(intval(round($_mksec/(3600*24))));
     }
 
 


### PR DESCRIPTION
the days between the due date and the real return date are calculated
by taking the unix-timestamp of each date, calculating the difference
and putting it in $_mksec. The days are then calculated by
intval($_mksec/(3600*24))
But if the daylight savings time changed inbetween, one of the days
has less than 3600*24 seconds. And because inval always rounds down,
the calculations counts one day fewer than it should.

My fix is to use round before the intval. The best solution would be
to use an existing library or PHP-functions for these calculations. But I'm not sure which library/functions work correctly in all cases