### PR TITLE
fix popup for customizing of themes

### DIFF
--- a/admin/modules/system/theme.php
+++ b/admin/modules/system/theme.php
@@ -111,10 +111,10 @@ if (isset($_GET['customize'])) {
     }
 
     // print out the form object
-    echo $form->printOut();
+    $content = $form->printOut();
 
   } else {
-    echo __('This theme not customizable');
+    $content = __('This theme not customizable');
   }
   require SB.'/admin/'.$sysconf['admin_template']['dir'].'/notemplate_page_tpl.php';
   exit();


### PR DESCRIPTION
the change in 8b700e8 results in a PHP-warning because $content is unset and it creates invalid HTML because the content is echoed before the starting html-tag

This pull request fixes both issues