### PR TITLE
Fixing color text in advance search

### DIFF
--- a/template/default/style.css
+++ b/template/default/style.css
@@ -564,6 +564,14 @@ a:hover {
   -webkit-animation-delay: 12s;
   animation-delay: 12s;
 }
+#hide-advance-search {
+  background-color: white;
+  padding-top: 10px;
+  border-radius: 20px;
+  padding-bottom: 5px;
+  padding-right: 5px;
+  padding-left: 5px;
+}
 .hide-header {
   position: absolute !important;
   top: 530px !important;
@@ -635,7 +643,7 @@ a:hover {
   line-height: 1;
   letter-spacing: 1px;
   font-size: 9pt;
-  color: #999;
+  color: white;
   font-weight: bold;
   text-transform: capitalize;
 }
@@ -646,7 +654,7 @@ a:hover {
 }
 #advance-search h2 {
   font-size: 10pt;
-  color: #39c;
+  color: white;
   line-height: 2;
 }
 @media only screen and (min-width: 768px) {


### PR DESCRIPTION
the default template have an update for lightweight slider library, advance search from is set with white smoke background color CMIIW. Now the background color of advance search in OPAC default template is transparent background. You can see the label, header and hamburger tag on right top is set with unmatch text color (#999 and #39c). I change and add some line to make it match with transparent background. :)
