### PR TITLE
Membercard gen bermasalah dalam bahasa Indonesia

### DIFF
--- a/lib/lang/php-gettext/gettext.inc
+++ b/lib/lang/php-gettext/gettext.inc
@@ -231,6 +231,8 @@ function _setlocale($category, $locale) {
         if (array_key_exists($default_domain, $text_domains)) {
             unset($text_domains[$default_domain]->l10n);
         }
+        // Fix comma number format in id_ID locale
+        setlocale(LC_NUMERIC, 'C');
         return $CURRENTLOCALE;
     }
 }


### PR DESCRIPTION
Setelah di analisis ternyata ada masalah pada pengaturan gettext nya. Cukup menambahkan setlocale('LC_NUMERIC', 'C') membercard tidak berantakan lagi, baik dalam bahasa inggris atau bahasa indonesia. Referensi https://processwire.com/talk/topic/4123-decimal-point-changed-to-in-base-of-setlocale/#elComment_142861