### PR TITLE
Galat : MySQL Server said : Can't find FULLTEXT

### DIFF
--- a/admin/modules/system/content.php
+++ b/admin/modules/system/content.php
@@ -253,7 +253,7 @@ if (isset($_POST['detail']) OR (isset($_GET['action']) AND $_GET['action'] == 'd
     $criteria = 'c.content_id IS NOT NULL ';
     if (isset($_GET['keywords']) AND $_GET['keywords']) {
        $keywords = $dbs->escape_string($_GET['keywords']);
-       $criteria .= " AND MATCH(content_title, content_desc) AGAINST('$keywords')";
+       $criteria .= " AND MATCH(content_title, content_desc) AGAINST('$keywords' IN BOOLEAN MODE)";
     }
     $datagrid->setSQLCriteria($criteria);
 


### PR DESCRIPTION
Ini terjadi pada versi database mariadb: 10.0.x dan 10.1.x juga pada mysql versi 5.5.62. Solusinya menambahkan kata "IN BOOLEAN MODE" karena tipe pencariannya menggunakan pecarian full text.

![Screenshot_2019-08-31_21-11-47](https://user-images.githubusercontent.com/38057222/64065215-e7c00e80-cc34-11e9-884e-b570597705cd.png)
