### PR TITLE
Nama session yang tidak sesuai.

### DIFF
--- a/lib/contents/member.inc.php
+++ b/lib/contents/member.inc.php
@@ -60,7 +60,7 @@ if (isset($_GET['destination'])) {
 // if member is logged out
 if (isset($_GET['logout']) && $_GET['logout'] == '1') {
     // write log
-    utility::writeLogs($dbs, 'member', $_SESSION['email'], 'Login', $_SESSION['member_name'].' Log Out from address '.$_SERVER['REMOTE_ADDR']);
+    utility::writeLogs($dbs, 'member', $_SESSION['email'], 'Login', $_SESSION['m_name'].' Log Out from address '.$_SERVER['REMOTE_ADDR']);
     // completely destroy session cookie
     simbio_security::destroySessionCookie(null, MEMBER_COOKIES_NAME, SWB, false);
     header('Location: index.php?p=member');


### PR DESCRIPTION
Di file member_logon.inc.php tidak medifinisikan $_SESSION['member_name'] tapi $_SESSION['m_name'], jadi setiap logout member namanya tidak tercatat di sistem.