### PR TITLE
Updated localisation.php : Australian English and Myanmar(Burmese) translations

### DIFF
--- a/lib/lang/localisation.php
+++ b/lib/lang/localisation.php
@@ -65,11 +65,15 @@ _textdomain($domain);
 $available_languages[] = array('ar_AR', __('Arabic'), 'Arabic');
 $available_languages[] = array('bn_BD', __('Bengali'), 'Bengali');
 $available_languages[] = array('pt_BR', __('Brazilian Portuguese'), 'Brazilian Portuguese');
-$available_languages[] = array('en_US', __('English'), 'English');
+$available_languages[] = array('en_AU', __('Australian English'), 'Australian English');
+$available_languages[] = array('en_US', __('US English'), 'US English');
 $available_languages[] = array('es_ES', __('Espanol'), 'Espanol');
 $available_languages[] = array('de_DE', __('German'), 'Deutsch');
 $available_languages[] = array('id_ID', __('Indonesian'), 'Indonesia');
 $available_languages[] = array('ja_JP', __('Japanese'), 'Japanese');
 $available_languages[] = array('th_TH', __('Thai'), 'Thai');
 $available_languages[] = array('my_MY', __('Malay'), 'Malay');
+$available_languages[] = array('my_MM', __('Myanmar (Burmese)'), 'Myanmar (Burmese)');
 $available_languages[] = array('fa_IR', __('Persian'), 'Persian');
+
+


### PR DESCRIPTION
Updated localisation.php to include and enable  **Australian English** and **Myanmar (Burmese)** in the list of available translations.